### PR TITLE
Feature/event/event type

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -2627,7 +2627,7 @@ paths:
         404:
           description: Couldn't find the event with the given event ID.
 
-  /events/types:
+  /event_types:
     get:
       tags: 
         - event

--- a/routes/api.php
+++ b/routes/api.php
@@ -1223,7 +1223,7 @@ Route::group(['prefix' => $url_prefix, 'middleware' => ['auth.basic']], function
         return "";
     });
 
-    Route::get('/events/types', function () {
+    Route::get('/event_types', function () {
         $eventtypes = Event_Type::getAll();
         return JSend::success("Event_Types", ['event_types' => $eventtypes]);
     });


### PR DESCRIPTION
Event Get call renamed from GET: 'events/types' to GET: 'event_types'. Changed documentation also